### PR TITLE
msm: acpuclock-krait: Only print supported number of frequencies once

### DIFF
--- a/arch/arm/mach-msm/acpuclock-krait.c
+++ b/arch/arm/mach-msm/acpuclock-krait.c
@@ -950,11 +950,12 @@ static struct cpufreq_frequency_table freq_table[NR_CPUS][35];
 static void __init cpufreq_table_init(void)
 {
 	int cpu;
+	int freq_cnt = 0;
 
 	for_each_possible_cpu(cpu) {
-		int i, freq_cnt = 0;
+		int i;
 		/* Construct the freq_table tables from acpu_freq_tbl. */
-		for (i = 0; drv.acpu_freq_tbl[i].speed.khz != 0
+		for (i = 0, freq_cnt = 0; drv.acpu_freq_tbl[i].speed.khz != 0
 				&& freq_cnt < ARRAY_SIZE(*freq_table)-1; i++) {
 			if (drv.acpu_freq_tbl[i].use_for_scaling) {
 				freq_table[cpu][freq_cnt].index = freq_cnt;
@@ -969,12 +970,11 @@ static void __init cpufreq_table_init(void)
 		freq_table[cpu][freq_cnt].index = freq_cnt;
 		freq_table[cpu][freq_cnt].frequency = CPUFREQ_TABLE_END;
 
-		dev_info(drv.dev, "CPU%d: %d frequencies supported\n",
-			cpu, freq_cnt);
-
 		/* Register table with CPUFreq. */
 		cpufreq_frequency_table_get_attr(freq_table[cpu], cpu);
 	}
+
+	dev_info(drv.dev, "CPU Frequencies Supported: %d\n", freq_cnt);
 }
 #else
 static void __init cpufreq_table_init(void) {}


### PR DESCRIPTION
We were missing this one last patch to make our acpuclock-krait.c in sync with Flo.
This patch is from official Flo kernel sources.

The current code prints the number of CPU frequencies supported
once for each possible CPU, even though the number of supported
frequencies is the same for each CPU. Cut down on log noise by
printing this number only once.

For example, print:

  [ 0.412932] acpuclk-8974 qcom,acpuclk.23: CPU Frequencies Supported: 11

...instead of:

  [ 0.426013] acpuclk-8974 qcom,acpuclk.23: CPU0: 11 frequencies supported
  [ 0.426052] acpuclk-8974 qcom,acpuclk.23: CPU1: 11 frequencies supported
  [ 0.426089] acpuclk-8974 qcom,acpuclk.23: CPU2: 11 frequencies supported
  [ 0.426124] acpuclk-8974 qcom,acpuclk.23: CPU3: 11 frequencies supported

Change-Id: Iaf15970e6cfcfaec79c0edf8564cab9141fbc05f
Signed-off-by: Matt Wagantall mattw@codeaurora.org

Conflicts:
    arch/arm/mach-msm/acpuclock-krait.c
