### PR TITLE
wcnss: Avoid user buffer overloading for write cal data

### DIFF
--- a/drivers/net/wireless/wcnss/wcnss_wlan.c
+++ b/drivers/net/wireless/wcnss/wcnss_wlan.c
@@ -1688,7 +1688,7 @@ static ssize_t wcnss_wlan_write(struct file *fp, const char __user
 		return -EFAULT;
 
 	if ((UINT32_MAX - count < penv->user_cal_rcvd) ||
-	     MAX_CALIBRATED_DATA_SIZE < count + penv->user_cal_rcvd) {
+		(penv->user_cal_exp_size < count + penv->user_cal_rcvd)) {
 		pr_err(DEVICE " invalid size to write %d\n", count +
 				penv->user_cal_rcvd);
 		rc = -ENOMEM;


### PR DESCRIPTION
compare size of allocated cal data buffer from heap
and count bytes provided to write by user to avoid
heap overflow for write cal data.

Change-Id: Id70c3230f761385489e5e94c613f4519239dfb1f
CRs-Fixed: 1032174
Signed-off-by: Anand Kumar anandkumar@codeaurora.org
